### PR TITLE
130 update jitar to 072

### DIFF
--- a/development.env
+++ b/development.env
@@ -20,6 +20,7 @@ MINIO_ACCESS_KEY="development"
 MINIO_SECRET_KEY="development"
 
 # AUTHENTICATION (openid)
+AUTHENTICATION_CLIENT_URI="http://localhost:5173/identify"
 AUTHENTICATION_IMPLEMENTATION="openid"
 OPENID_ISSUER="http://localhost:8080/realms/comify"
 OPENID_CLIENT_ID="openid"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "dayjs": "^1.11.10",
-        "jitar": "^0.7.1",
+        "jitar": "^0.7.2",
         "minio": "^7.1.3",
         "mongodb": "^6.3.0",
         "openid-client": "^5.6.4",
@@ -4520,9 +4520,9 @@
       }
     },
     "node_modules/jitar": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/jitar/-/jitar-0.7.1.tgz",
-      "integrity": "sha512-a25ZNHSX/G+G0Purh+/rChXIgL0+RIfl1w4LlhOe3Nwch+PLwB4QzkAu9w+jxzKp689slrLCYx/LxABkTkYV5g==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/jitar/-/jitar-0.7.2.tgz",
+      "integrity": "sha512-/rIIMe6TwLjbsjSH9Kndbp/AGgTzEAxLotmd9eP3IPGLzcMOZzTwUpdt+Agxc1SwDbisgsemm5ofxtYV+MtvoA==",
       "dependencies": {
         "express": "^4.18.2",
         "express-http-proxy": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "dayjs": "^1.11.10",
-    "jitar": "^0.7.1",
+    "jitar": "^0.7.2",
     "minio": "^7.1.3",
     "mongodb": "^6.3.0",
     "openid-client": "^5.6.4",

--- a/services/standalone.json
+++ b/services/standalone.json
@@ -16,6 +16,7 @@
     "standalone":
     {
         "trustKey": "${JITAR_TRUST_KEY}",
+        "serveIndexOnNotFound": true,
         "assets": ["index.html", "main.js", "assets/**/*", "webui/**/*"],
         "segments": ["authentication", "webui"],
         "middlewares": [

--- a/src/integrations/jitar/authenticationMiddleware.ts
+++ b/src/integrations/jitar/authenticationMiddleware.ts
@@ -8,7 +8,7 @@ const authProcedures = {
     logout: 'domain/authentication/logout'
 };
 
-const redirectUrl = 'http://localhost:5173/identify';
+const redirectUrl = process.env.AUTHENTICATION_CLIENT_URI || 'undefined';
 
 const whiteList: string[] = [];
 


### PR DESCRIPTION
Fixes #130 

Changes proposed in this pull request:
- Updated Jitar to version 0.7.2
- Added `serveIndexOnNotFound` to the standalone configuration
- Made the auth client redirect url configurable trough the environment

@MaskingTechnology/comify
