### PR TITLE
chore: update id of reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,4 @@ updates:
     reviewers:
       - "basmasking"
       - "petermasking"
-      - "johnatmasking"
+      - "johnmasking"


### PR DESCRIPTION
Changes proposed in this pull request:
- Changed the id of John after his username has been updated

@MaskingTechnology/comify
