### PR TITLE
bug(integrations): fix health status for database

### DIFF
--- a/src/integrations/database/implementations/mongodb/MongoDb.ts
+++ b/src/integrations/database/implementations/mongodb/MongoDb.ts
@@ -60,11 +60,12 @@ export default class MongoDB implements Driver
             this.#client = await this.#createClient(this.#connectionString);
 
             this.#client.on('close', () => { this.#connected = false; });
-
             this.#client.on('serverHeartbeatSucceeded', () => { this.#connected = true; });
             this.#client.on('serverHeartbeatFailed', () => { this.#connected = false; });
 
             this.#database = this.#getDatabase(this.#databaseName);
+
+            this.#connected = true;
         }
         catch (error: unknown)
         {
@@ -265,20 +266,7 @@ export default class MongoDB implements Driver
 
     async #createClient(connectionString: string): Promise<MongoClient>
     {
-        try
-        {
-            const client = await MongoClient.connect(connectionString);
-
-            this.#connected = true;
-
-            return client;
-        }
-        catch (error: unknown)
-        {
-            const message = error instanceof Error ? error.message : undefined;
-
-            throw new NotConnected(message);
-        }
+        return MongoClient.connect(connectionString);
     }
 
     #buildRecordData(data: Document, fields?: RecordField[]): RecordData

--- a/src/integrations/database/implementations/mongodb/MongoDb.ts
+++ b/src/integrations/database/implementations/mongodb/MongoDb.ts
@@ -51,10 +51,7 @@ export default class MongoDB implements Driver
         this.#databaseName = databaseName;
     }
 
-    get connected()
-    {
-        return this.#connected;
-    }
+    get connected() { return this.#connected; }
 
     async connect(): Promise<void>
     {
@@ -62,7 +59,6 @@ export default class MongoDB implements Driver
         {
             this.#client = await this.#createClient(this.#connectionString);
 
-            this.#client.on('open', () => { this.#connected = true; });
             this.#client.on('close', () => { this.#connected = false; });
 
             this.#client.on('serverHeartbeatSucceeded', () => { this.#connected = true; });
@@ -271,7 +267,11 @@ export default class MongoDB implements Driver
     {
         try
         {
-            return await MongoClient.connect(connectionString);
+            const client = await MongoClient.connect(connectionString);
+
+            this.#connected = true;
+
+            return client;
         }
         catch (error: unknown)
         {


### PR DESCRIPTION
Fixes #366 

Changes proposed in this pull request:
- MongoClient.connect() returns an opened connection, so we don't need to listen for that and can set `#connected` afterwards.

@MaskingTechnology/comify
