### PR TITLE
feat: bulk db operations

### DIFF
--- a/src/integrations/database/Database.ts
+++ b/src/integrations/database/Database.ts
@@ -15,14 +15,14 @@ export default class Database implements Driver
 
     get connected() { return this.#driver.connected; }
 
+    clear(): Promise<void>
+    {
+        return this.#driver.clear();
+    }
+
     connect(): Promise<void>
     {
         return this.#driver.connect();
-    }
-
-    disconnect(): Promise<void>
-    {
-        return this.#driver.disconnect();
     }
 
     createRecord(type: RecordType, data: RecordData): Promise<RecordId>
@@ -32,9 +32,34 @@ export default class Database implements Driver
         return this.#driver.createRecord(type, cleanData);
     }
 
+    deleteRecord(type: RecordType, id: RecordId): Promise<void>
+    {
+        return this.#driver.deleteRecord(type, id);
+    }
+
+    deleteRecords(type: RecordType, query: RecordQuery): Promise<void>
+    {
+        return this.#driver.deleteRecords(type, query);
+    }
+
+    disconnect(): Promise<void>
+    {
+        return this.#driver.disconnect();
+    }
+
+    findRecord(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort): Promise<RecordData | undefined>
+    {
+        return this.#driver.findRecord(type, query, fields, sort);
+    }
+
     readRecord(type: RecordType, id: RecordId, fields?: RecordField[]): Promise<RecordData>
     {
         return this.#driver.readRecord(type, id, fields);
+    }
+
+    searchRecords(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort, limit?: number, offset?: number): Promise<RecordData[]>
+    {
+        return this.#driver.searchRecords(type, query, fields, sort, limit, offset);
     }
 
     updateRecord(type: RecordType, id: RecordId, data: RecordData): Promise<void>
@@ -44,34 +69,10 @@ export default class Database implements Driver
         return this.#driver.updateRecord(type, id, cleanData);
     }
 
-    deleteRecord(type: RecordType, id: RecordId): Promise<void>
-    {
-        return this.#driver.deleteRecord(type, id);
-    }
-
-    findRecord(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort): Promise<RecordData | undefined>
-    {
-        return this.#driver.findRecord(type, query, fields, sort);
-    }
-
-    searchRecords(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort, limit?: number, offset?: number): Promise<RecordData[]>
-    {
-        return this.#driver.searchRecords(type, query, fields, sort, limit, offset);
-    }
-
     updateRecords(type: RecordType, query: RecordQuery, data: RecordData): Promise<void>
     {
+        const cleanData = sanitize(data);
 
-        return this.#driver.updateRecords(type, query, data);
-    }
-
-    deleteRecords(type: RecordType, query: RecordQuery): Promise<void>
-    {
-        return this.#driver.deleteRecords(type, query);
-    }
-
-    clear(): Promise<void>
-    {
-        return this.#driver.clear();
+        return this.#driver.updateRecords(type, query, cleanData);
     }
 }

--- a/src/integrations/database/Database.ts
+++ b/src/integrations/database/Database.ts
@@ -15,14 +15,14 @@ export default class Database implements Driver
 
     get connected() { return this.#driver.connected; }
 
-    clear(): Promise<void>
-    {
-        return this.#driver.clear();
-    }
-
     connect(): Promise<void>
     {
         return this.#driver.connect();
+    }
+
+    disconnect(): Promise<void>
+    {
+        return this.#driver.disconnect();
     }
 
     createRecord(type: RecordType, data: RecordData): Promise<RecordId>
@@ -32,29 +32,14 @@ export default class Database implements Driver
         return this.#driver.createRecord(type, cleanData);
     }
 
-    deleteRecord(type: RecordType, id: RecordId): Promise<void>
+    readRecord(type: RecordType, id: RecordId, fields?: RecordField[]): Promise<RecordData>
     {
-        return this.#driver.deleteRecord(type, id);
-    }
-
-    deleteRecords(type: RecordType, query: RecordQuery): Promise<void>
-    {
-        return this.#driver.deleteRecords(type, query);
-    }
-
-    disconnect(): Promise<void>
-    {
-        return this.#driver.disconnect();
+        return this.#driver.readRecord(type, id, fields);
     }
 
     findRecord(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort): Promise<RecordData | undefined>
     {
         return this.#driver.findRecord(type, query, fields, sort);
-    }
-
-    readRecord(type: RecordType, id: RecordId, fields?: RecordField[]): Promise<RecordData>
-    {
-        return this.#driver.readRecord(type, id, fields);
     }
 
     searchRecords(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort, limit?: number, offset?: number): Promise<RecordData[]>
@@ -74,5 +59,20 @@ export default class Database implements Driver
         const cleanData = sanitize(data);
 
         return this.#driver.updateRecords(type, query, cleanData);
+    }
+
+    deleteRecord(type: RecordType, id: RecordId): Promise<void>
+    {
+        return this.#driver.deleteRecord(type, id);
+    }
+
+    deleteRecords(type: RecordType, query: RecordQuery): Promise<void>
+    {
+        return this.#driver.deleteRecords(type, query);
+    }
+
+    clear(): Promise<void>
+    {
+        return this.#driver.clear();
     }
 }

--- a/src/integrations/database/Database.ts
+++ b/src/integrations/database/Database.ts
@@ -59,6 +59,17 @@ export default class Database implements Driver
         return this.#driver.searchRecords(type, query, fields, sort, limit, offset);
     }
 
+    updateRecords(type: RecordType, query: RecordQuery, data: RecordData): Promise<void>
+    {
+
+        return this.#driver.updateRecords(type, query, data);
+    }
+
+    deleteRecords(type: RecordType, query: RecordQuery): Promise<void>
+    {
+        return this.#driver.deleteRecords(type, query);
+    }
+
     clear(): Promise<void>
     {
         return this.#driver.clear();

--- a/src/integrations/database/definitions/interfaces.ts
+++ b/src/integrations/database/definitions/interfaces.ts
@@ -13,5 +13,7 @@ export interface Driver
     deleteRecord(type: RecordType, id: RecordId): Promise<void>;
     findRecord(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort): Promise<RecordData | undefined>;
     searchRecords(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort, limit?: number, offset?: number): Promise<RecordData[]>;
+    updateRecords(type: RecordType, query: RecordQuery, data: RecordData): Promise<void>;
+    deleteRecords(type: RecordType, query: RecordQuery): Promise<void>;
     clear(): Promise<void>;
 }

--- a/src/integrations/database/definitions/interfaces.ts
+++ b/src/integrations/database/definitions/interfaces.ts
@@ -9,11 +9,11 @@ export interface Driver
     disconnect(): Promise<void>;
     createRecord(type: RecordType, data: RecordData): Promise<RecordId>;
     readRecord(type: RecordType, id: RecordId, fields?: RecordField[]): Promise<RecordData>;
-    updateRecord(type: RecordType, id: RecordId, data: RecordData): Promise<void>;
-    deleteRecord(type: RecordType, id: RecordId): Promise<void>;
     findRecord(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort): Promise<RecordData | undefined>;
     searchRecords(type: RecordType, query: RecordQuery, fields?: RecordField[], sort?: RecordSort, limit?: number, offset?: number): Promise<RecordData[]>;
+    updateRecord(type: RecordType, id: RecordId, data: RecordData): Promise<void>;
     updateRecords(type: RecordType, query: RecordQuery, data: RecordData): Promise<void>;
+    deleteRecord(type: RecordType, id: RecordId): Promise<void>;
     deleteRecords(type: RecordType, query: RecordQuery): Promise<void>;
     clear(): Promise<void>;
 }

--- a/src/integrations/database/errors/RecordsNotDeleted.ts
+++ b/src/integrations/database/errors/RecordsNotDeleted.ts
@@ -1,0 +1,10 @@
+
+import DatabaseError from './DatabaseError';
+
+export default class RecordsNotDeleted extends DatabaseError
+{
+    constructor(message?: string)
+    {
+        super(message ?? 'Records not deleted');
+    }
+}

--- a/src/integrations/database/errors/RecordsNotUpdated.ts
+++ b/src/integrations/database/errors/RecordsNotUpdated.ts
@@ -1,0 +1,10 @@
+
+import DatabaseError from './DatabaseError';
+
+export default class RecordsNotUpdated extends DatabaseError
+{
+    constructor(message?: string)
+    {
+        super(message ?? 'Records not updated');
+    }
+}

--- a/src/integrations/database/implementations/memory/Memory.ts
+++ b/src/integrations/database/implementations/memory/Memory.ts
@@ -121,9 +121,9 @@ export default class Memory implements Driver
         const filterFunction = this.#buildFilterFunction(query);
         const collection = this.#getCollection(type);
         const records = collection.filter(filterFunction);
-        records.map(item => 
+        records.forEach(element =>
         {
-            const record = collection.find(object => object.id === item.id);
+            const record = collection.find(object => object.id === element.id);
 
             if (record === undefined)
             {
@@ -133,7 +133,8 @@ export default class Memory implements Driver
             for (const key of Object.keys(data))
             {
                 record[key] = data[key];
-            }
+            };
+
         });
     }
 
@@ -142,9 +143,9 @@ export default class Memory implements Driver
         const filterFunction = this.#buildFilterFunction(query);
         const collection = this.#getCollection(type);
         const records = collection.filter(filterFunction);
-        records.map(item =>
+        records.forEach(element =>
         {
-            const index = collection.findIndex(object => object.id === item.id);
+            const index = collection.findIndex(object => object.id === element.id);
 
             if (index === -1)
             {

--- a/src/integrations/database/implementations/memory/Memory.ts
+++ b/src/integrations/database/implementations/memory/Memory.ts
@@ -116,6 +116,45 @@ export default class Memory implements Driver
         return limitedResult.map(records => this.#buildRecordData(records, fields));
     }
 
+    async updateRecords(type: string, query: QueryStatement, data: RecordData): Promise<void>
+    {
+        const filterFunction = this.#buildFilterFunction(query);
+        const collection = this.#getCollection(type);
+        const records = collection.filter(filterFunction);
+        records.map(item => 
+        {
+            const record = collection.find(object => object.id === item.id);
+
+            if (record === undefined)
+            {
+                throw new RecordNotUpdated();
+            }
+
+            for (const key of Object.keys(data))
+            {
+                record[key] = data[key];
+            }
+        });
+    }
+
+    async deleteRecords(type: string, query: QueryStatement): Promise<void>
+    {
+        const filterFunction = this.#buildFilterFunction(query);
+        const collection = this.#getCollection(type);
+        const records = collection.filter(filterFunction);
+        records.map(item =>
+        {
+            const index = collection.findIndex(object => object.id === item.id);
+
+            if (index === -1)
+            {
+                throw new RecordNotFound();
+            }
+
+            collection.splice(index, 1);
+        });
+    }
+
     async clear(): Promise<void>
     {
         this.#memory.clear();

--- a/src/integrations/database/implementations/memory/Memory.ts
+++ b/src/integrations/database/implementations/memory/Memory.ts
@@ -116,11 +116,6 @@ export default class Memory implements Driver
         collection.splice(index, 1);
     }
 
-    async clear(): Promise<void>
-    {
-        this.#memory.clear();
-    }
-
     async deleteRecords(type: string, query: QueryStatement): Promise<void>
     {
         const collection = this.#getCollection(type);
@@ -131,6 +126,11 @@ export default class Memory implements Driver
             .sort((a, b) => b - a); // Reverse the order of indexes to delete from the end to the beginning
 
         indexes.forEach(index => collection.splice(index, 1));
+    }
+
+    async clear(): Promise<void>
+    {
+        this.#memory.clear();
     }
 
     #fetchRecord(type: string, id: string)

--- a/src/integrations/database/implementations/mongodb/MongoDb.ts
+++ b/src/integrations/database/implementations/mongodb/MongoDb.ts
@@ -177,6 +177,30 @@ export default class MongoDB implements Driver
         return result.map(data => this.#buildRecordData(data, fields));
     }
 
+    async updateRecords(type: RecordType, query: RecordQuery, data: RecordData): Promise<void>
+    {
+        const mongoQuery = this.#buildMongoQuery(query);
+
+        const collection = await this.#getCollection(type);
+        const result = await collection.updateMany(mongoQuery, { $set: data });
+        if (result.acknowledged === false)
+        {
+            throw new DatabaseError();
+        }
+    }
+
+    async deleteRecords(type: RecordType, query: RecordQuery): Promise<void>
+    {
+        const mongoQuery = this.#buildMongoQuery(query);
+
+        const collection = await this.#getCollection(type);
+        const result = await collection.deleteMany(mongoQuery);
+        if (result.acknowledged === false)
+        {
+            throw new DatabaseError();
+        }
+    }
+
     async clear(): Promise<void>
     {
         return; // Deliberately not implemented

--- a/test/integrations/database/fixtures/queries.fixture.ts
+++ b/test/integrations/database/fixtures/queries.fixture.ts
@@ -7,6 +7,7 @@ const { CALZONE, VEGETARIAN, HAWAII } = RECORDS.PIZZAS;
 
 export const QUERIES: Record<string, RecordQuery> =
 {
+    UPDATED: { size: { EQUALS: 40 } },
     EMPTY: {},
     NO_MATCH: { name: { EQUALS: 'Not existing' } },
 

--- a/test/integrations/database/fixtures/values.fixture.ts
+++ b/test/integrations/database/fixtures/values.fixture.ts
@@ -20,5 +20,10 @@ export const VALUES =
     UPDATES:
     {
         COUNTRY: 'France'
+    },
+
+    SIZE:
+    {
+        size: 40
     }
 };

--- a/test/integrations/database/fixtures/values.fixture.ts
+++ b/test/integrations/database/fixtures/values.fixture.ts
@@ -25,5 +25,10 @@ export const VALUES =
     SIZE:
     {
         size: 40
+    },
+
+    NO_MATCH_SIZE:
+    {
+        size: 99
     }
 };

--- a/test/integrations/database/implementation.spec.ts
+++ b/test/integrations/database/implementation.spec.ts
@@ -35,25 +35,41 @@ describe('integrations/database/implementation', () =>
             expect(result?.folded).toBeFalsy();
         });
 
-        describe('.findRecord', () =>
-        {
-            it('should return the first matched record', async () =>
-            {
-                const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
-                expect(result).toMatchObject(RECORDS.PIZZAS.MARGHERITA);
-            });
+    });
 
-            it('should return undefined when no match found', async () =>
-            {
-                const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH);
-                expect(result).toBe(undefined);
-            });
+    describe('.findRecord', () =>
+    {
+        it('should return the first matched record', async () =>
+        {
+            const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
+            expect(result).toMatchObject(RECORDS.PIZZAS.MARGHERITA);
+        });
+
+        it('should return undefined when no match found', async () =>
+        {
+            const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH);
+            expect(result).toBe(undefined);
         });
 
         it('should throw an error when a record is not found', async () =>
         {
             const promise = database.readRecord(RECORD_TYPES.PIZZAS, VALUES.IDS.NON_EXISTING);
             await expect(promise).rejects.toStrictEqual(new RecordNotFound());
+        });
+    });
+
+    describe('.findRecord', () =>
+    {
+        it('should return the first matched record', async () =>
+        {
+            const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
+            expect(result).toMatchObject(RECORDS.PIZZAS.MARGHERITA);
+        });
+
+        it('should return undefined when no match found', async () =>
+        {
+            const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH);
+            expect(result).toBe(undefined);
         });
     });
 

--- a/test/integrations/database/implementation.spec.ts
+++ b/test/integrations/database/implementation.spec.ts
@@ -221,13 +221,13 @@ describe('integrations/database/implementation', () =>
 
             const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.UPDATED);
             expect(records).toHaveLength(2);
-            expect(records[0].size).toBe(40);
-            expect(records[1].size).toBe(40);
+            expect(records[0].size).toBe(VALUES.SIZE.size);
+            expect(records[1].size).toBe(VALUES.SIZE.size);
         });
 
         it('should not throw an error when no records match the query', async () =>
         {
-            const data: RecordData = { size: 99 };
+            const data: RecordData = VALUES.NO_MATCH_SIZE;
 
             // This should not throw an error
             await expect(database.updateRecords(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH, data))

--- a/test/integrations/database/implementation.spec.ts
+++ b/test/integrations/database/implementation.spec.ts
@@ -1,6 +1,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import type { RecordData } from '^/integrations/database';
 import database, { RecordNotFound, RecordNotUpdated } from '^/integrations/database';
 
 import { DATABASES, QUERIES, RECORDS, RECORD_TYPES, RESULTS, SORTS, VALUES } from './fixtures';
@@ -59,6 +60,18 @@ describe('integrations/database/implementation', () =>
         });
     });
 
+    describe('.deleteRecords', () =>
+    {
+        it('should delete all records matching the query', async () =>
+        {
+            await database.deleteRecords(RECORD_TYPES.PIZZAS, QUERIES.EQUALS);
+
+            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EQUALS);
+            expect(records).toHaveLength(0);
+        });
+
+    });
+
     describe('.updateRecord', () =>
     {
         it('should update a record by id', async () =>
@@ -75,6 +88,18 @@ describe('integrations/database/implementation', () =>
         {
             const promise = database.updateRecord(RECORD_TYPES.FRUITS, VALUES.IDS.NON_EXISTING, {});
             await expect(promise).rejects.toStrictEqual(new RecordNotUpdated());
+        });
+    });
+
+    describe('.updateRecords', () =>
+    {
+        it('should update all records matching the query', async () =>
+        {
+            const data: RecordData = { size: 40 };
+            await database.updateRecords(RECORD_TYPES.PIZZAS, QUERIES.EQUALS, data);
+
+            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.UPDATED);
+            expect(records).toHaveLength(2);
         });
     });
 

--- a/test/integrations/database/implementation.spec.ts
+++ b/test/integrations/database/implementation.spec.ts
@@ -14,45 +14,6 @@ beforeEach(async () =>
 describe('integrations/database/implementation', () =>
 {
 
-    describe('.deleteRecord', () =>
-    {
-        it('should delete a record by id', async () =>
-        {
-            const id = RECORDS.FRUITS.APPLE.id as string;
-
-            await database.deleteRecord(RECORD_TYPES.FRUITS, id);
-
-            const promise = database.readRecord(RECORD_TYPES.FRUITS, id);
-            await expect(promise).rejects.toStrictEqual(new RecordNotFound());
-        });
-
-        it('should throw an error when the record cannot be deleted', async () =>
-        {
-            const promise = database.deleteRecord(RECORD_TYPES.PIZZAS, VALUES.IDS.NON_EXISTING);
-            await expect(promise).rejects.toStrictEqual(new RecordNotFound());
-        });
-    });
-
-    describe('.deleteRecords', () =>
-    {
-        it('should delete all records matching the query', async () =>
-        {
-            await database.deleteRecords(RECORD_TYPES.PIZZAS, QUERIES.EQUALS);
-
-            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EQUALS);
-            expect(records).toHaveLength(0);
-        });
-
-        it('should not throw an error when no records match the query', async () =>
-        {
-            await expect(database.deleteRecords(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH))
-                .resolves.toBeUndefined();
-
-            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
-            expect(records).toHaveLength(5);
-        });
-    });
-
     describe('.findRecord', () =>
     {
         it('should return the first matched record', async () =>
@@ -65,23 +26,6 @@ describe('integrations/database/implementation', () =>
         {
             const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH);
             expect(result).toBe(undefined);
-        });
-    });
-
-    describe('.limitNumberOfRecords', () =>
-    {
-        it('should limit the result', async () =>
-        {
-            const result = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY, undefined, undefined, 2);
-            expect(result).toHaveLength(2);
-            expect(result).toMatchObject(RESULTS.LIMITED_BY_NUMBER);
-        });
-
-        it('should give the result starting an offset', async () =>
-        {
-            const result = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY, undefined, undefined, undefined, 2);
-            expect(result).toHaveLength(3);
-            expect(result).toMatchObject(RESULTS.LIMITED_BY_OFFSET);
         });
     });
 
@@ -233,6 +177,104 @@ describe('integrations/database/implementation', () =>
         });
     });
 
+    describe('.updateRecord', () =>
+    {
+        it('should update a record by id', async () =>
+        {
+            const id = RECORDS.FRUITS.PEAR.id as string;
+
+            await database.updateRecord(RECORD_TYPES.FRUITS, id, { country: VALUES.UPDATES.COUNTRY });
+
+            const result = await database.readRecord(RECORD_TYPES.FRUITS, id);
+            expect(result?.country).toBe(VALUES.UPDATES.COUNTRY);
+        });
+
+        it('should throw an error when record cannot be updated', async () =>
+        {
+            const promise = database.updateRecord(RECORD_TYPES.FRUITS, VALUES.IDS.NON_EXISTING, {});
+            await expect(promise).rejects.toStrictEqual(new RecordNotUpdated());
+        });
+    });
+
+    describe('.updateRecords', () =>
+    {
+        it('should update all records matching the query', async () =>
+        {
+            const data: RecordData = VALUES.SIZE;
+            await database.updateRecords(RECORD_TYPES.PIZZAS, QUERIES.EQUALS, data);
+
+            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.UPDATED);
+            expect(records).toHaveLength(2);
+            expect(records[0].size).toBe(40);
+            expect(records[1].size).toBe(40);
+        });
+
+        it('should not throw an error when no records match the query', async () =>
+        {
+            const data: RecordData = { size: 99 };
+
+            // This should not throw an error
+            await expect(database.updateRecords(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH, data))
+                .resolves.toBeUndefined();
+        });
+    });
+
+    describe('.deleteRecord', () =>
+    {
+        it('should delete a record by id', async () =>
+        {
+            const id = RECORDS.FRUITS.APPLE.id as string;
+
+            await database.deleteRecord(RECORD_TYPES.FRUITS, id);
+
+            const promise = database.readRecord(RECORD_TYPES.FRUITS, id);
+            await expect(promise).rejects.toStrictEqual(new RecordNotFound());
+        });
+
+        it('should throw an error when the record cannot be deleted', async () =>
+        {
+            const promise = database.deleteRecord(RECORD_TYPES.PIZZAS, VALUES.IDS.NON_EXISTING);
+            await expect(promise).rejects.toStrictEqual(new RecordNotFound());
+        });
+    });
+
+    describe('.deleteRecords', () =>
+    {
+        it('should delete all records matching the query', async () =>
+        {
+            await database.deleteRecords(RECORD_TYPES.PIZZAS, QUERIES.EQUALS);
+
+            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EQUALS);
+            expect(records).toHaveLength(0);
+        });
+
+        it('should not throw an error when no records match the query', async () =>
+        {
+            await expect(database.deleteRecords(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH))
+                .resolves.toBeUndefined();
+
+            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
+            expect(records).toHaveLength(5);
+        });
+    });
+
+    describe('.limitNumberOfRecords', () =>
+    {
+        it('should limit the result', async () =>
+        {
+            const result = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY, undefined, undefined, 2);
+            expect(result).toHaveLength(2);
+            expect(result).toMatchObject(RESULTS.LIMITED_BY_NUMBER);
+        });
+
+        it('should give the result starting an offset', async () =>
+        {
+            const result = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY, undefined, undefined, undefined, 2);
+            expect(result).toHaveLength(3);
+            expect(result).toMatchObject(RESULTS.LIMITED_BY_OFFSET);
+        });
+    });
+
     describe('.sortRecords', () =>
     {
         it('should sort records ascending', async () =>
@@ -261,48 +303,6 @@ describe('integrations/database/implementation', () =>
             const result = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY, undefined, SORTS.MULTIPLE_DIFFERENT);
             expect(result).toHaveLength(5);
             expect(result).toMatchObject(RESULTS.SORTED_MULTIPLE_DIFFERENT);
-        });
-    });
-
-    describe('.updateRecord', () =>
-    {
-        it('should update a record by id', async () =>
-        {
-            const id = RECORDS.FRUITS.PEAR.id as string;
-
-            await database.updateRecord(RECORD_TYPES.FRUITS, id, { country: VALUES.UPDATES.COUNTRY });
-
-            const result = await database.readRecord(RECORD_TYPES.FRUITS, id);
-            expect(result?.country).toBe(VALUES.UPDATES.COUNTRY);
-        });
-
-        it('should throw an error when record cannot be updated', async () =>
-        {
-            const promise = database.updateRecord(RECORD_TYPES.FRUITS, VALUES.IDS.NON_EXISTING, {});
-            await expect(promise).rejects.toStrictEqual(new RecordNotUpdated());
-        });
-    });
-
-    describe('.updateRecords', () =>
-    {
-        it('should update all records matching the query', async () =>
-        {
-            const data: RecordData = { size: 40 };
-            await database.updateRecords(RECORD_TYPES.PIZZAS, QUERIES.EQUALS, data);
-
-            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.UPDATED);
-            expect(records).toHaveLength(2);
-            expect(records[0].size).toBe(40);
-            expect(records[1].size).toBe(40);
-        });
-
-        it('should not throw an error when no records match the query', async () =>
-        {
-            const data: RecordData = { size: 99 };
-
-            // This should not throw an error
-            await expect(database.updateRecords(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH, data))
-                .resolves.toBeUndefined();
         });
     });
 });

--- a/test/integrations/database/implementation.spec.ts
+++ b/test/integrations/database/implementation.spec.ts
@@ -14,21 +14,6 @@ beforeEach(async () =>
 describe('integrations/database/implementation', () =>
 {
 
-    describe('.findRecord', () =>
-    {
-        it('should return the first matched record', async () =>
-        {
-            const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
-            expect(result).toMatchObject(RECORDS.PIZZAS.MARGHERITA);
-        });
-
-        it('should return undefined when no match found', async () =>
-        {
-            const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH);
-            expect(result).toBe(undefined);
-        });
-    });
-
     describe('.readRecord', () =>
     {
         it('should read a full record by id', async () =>
@@ -48,6 +33,21 @@ describe('integrations/database/implementation', () =>
             expect(Object.keys(result)).toHaveLength(2);
             expect(result?.id).toBe(id);
             expect(result?.folded).toBeFalsy();
+        });
+
+        describe('.findRecord', () =>
+        {
+            it('should return the first matched record', async () =>
+            {
+                const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
+                expect(result).toMatchObject(RECORDS.PIZZAS.MARGHERITA);
+            });
+
+            it('should return undefined when no match found', async () =>
+            {
+                const result = await database.findRecord(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH);
+                expect(result).toBe(undefined);
+            });
         });
 
         it('should throw an error when a record is not found', async () =>

--- a/test/integrations/database/implementation.spec.ts
+++ b/test/integrations/database/implementation.spec.ts
@@ -43,14 +43,14 @@ describe('integrations/database/implementation', () =>
             expect(records).toHaveLength(0);
         });
 
-        it('should not throw an error when no records match the query', async () =>
-        {
-            await expect(database.deleteRecords(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH))
-                .resolves.toBeUndefined();
+        // it('should not throw an error when no records match the query', async () =>
+        // {
+        //     await expect(database.deleteRecords(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH))
+        //         .resolves.toBeUndefined();
 
-            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
-            expect(records).toHaveLength(5);
-        });
+        //     const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
+        //     expect(records).toHaveLength(5);
+        // });
     });
 
     describe('.findRecord', () =>

--- a/test/integrations/database/implementation.spec.ts
+++ b/test/integrations/database/implementation.spec.ts
@@ -43,14 +43,14 @@ describe('integrations/database/implementation', () =>
             expect(records).toHaveLength(0);
         });
 
-        // it('should not throw an error when no records match the query', async () =>
-        // {
-        //     await expect(database.deleteRecords(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH))
-        //         .resolves.toBeUndefined();
+        it('should not throw an error when no records match the query', async () =>
+        {
+            await expect(database.deleteRecords(RECORD_TYPES.PIZZAS, QUERIES.NO_MATCH))
+                .resolves.toBeUndefined();
 
-        //     const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
-        //     expect(records).toHaveLength(5);
-        // });
+            const records = await database.searchRecords(RECORD_TYPES.PIZZAS, QUERIES.EMPTY);
+            expect(records).toHaveLength(5);
+        });
     });
 
     describe('.findRecord', () =>


### PR DESCRIPTION
Fixes #401 

Changes proposed in this pull request:
- create updateRecords in interface
- create deleteRecords in interface
- create updateRecords implementation in MongoDB
- create updateRecords iimplementation in Memory
- create deleteRecords implementation in MongoDB
- create deleteRecords implementation in Memory
- create tests

@MaskingTechnology/comify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced bulk record update and deletion capabilities, allowing more efficient data management with improved filtering for precise record selection.
	- Added new methods for searching and finding records, improving data retrieval functionality.
	- Added a new query option to enhance filtering criteria in database queries.
	- Introduced new error classes for improved error handling related to record operations.

- **Bug Fixes**
	- Enhanced error handling for record update and deletion operations to ensure better reliability.

- **Tests**
	- Expanded test coverage to ensure the reliability and robustness of the new bulk operations, including new test suites for deleting and updating multiple records.
	- Added tests for limiting search results and verifying sorting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->