### PR TITLE
chore: use github CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @basmasking @petermasking

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,3 @@ updates:
     pull-request-branch-name:
       # Separate sections of the branch name with a hyphen
       separator: "-"
-    reviewers:
-      - "basmasking"
-      - "petermasking"
-      - "johnmasking"


### PR DESCRIPTION
Fixes #420 

Changes proposed in this pull request:
- CODEOWNERS for reviews
- removed the deprecated `reviewers` config for dependabot 

@MaskingTechnology/comify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a CODEOWNERS file to automatically assign @basmasking and @petermasking as reviewers for all pull requests.
	- Updated Dependabot configuration to stop automatically requesting specific reviewers for npm dependency update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->